### PR TITLE
Change prefect log to loguru

### DIFF
--- a/src/master.py
+++ b/src/master.py
@@ -1,6 +1,7 @@
 from datetime import date
 from prefect import Flow
 from prefect import Parameter
+from prefect.utilities import logging
 
 from global_utilities.log import log
 
@@ -9,6 +10,8 @@ from flights import merge_flights_history
 from money_lover import money_lover
 from reports import reports
 
+# Replace loguru log
+logging.get_logger = lambda x: log
 
 with Flow("do_all") as flow:
     mdate = Parameter("mdate")


### PR DESCRIPTION
The default log for `prefect` is not as beautiful and useful as `loguru`.

This PR overwrittes the prefect `get_logger` function from https://github.com/PrefectHQ/prefect/blob/master/src/prefect/utilities/logging.py so that it returns `loguru` log instead.