### PR TITLE
Fix documented bugs, redact MD token, prune resolved IMPROVEMENTS items (7.6.2)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,7 +35,7 @@ jobs:
   integration_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,8 +157,6 @@ Deployments and their schedules are defined in `prefect.yaml`.
 - `paths.ENV` is computed at import time; changing env vars after import has no effect.
 - Running modules with `python path/to/file.py` will break relative imports — always use
   `python -m vtasks.<...>`.
-- `vtasks/jobs/local/maintain.py` currently has known bugs (see `IMPROVEMENTS.md`) — don't
-  treat it as a working reference.
 - `requests` and `loguru` are imported directly but are only transitive dependencies (not
   declared in `pyproject.toml`).
 - Windows is a first-class local environment (the repo lives on `C:\`); `paths.py`

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,47 +1,14 @@
 # IMPROVEMENTS.md
 
 Suggested improvements for `vtasks`, ordered roughly by impact. Each item notes the
-affected file(s) and why it matters. Bugs come first because they are likely already
-breaking flows in production.
+affected file(s) and why it matters.
 
-## 🐞 Correctness bugs (fix first)
-
-### 1. `maintain.sync_duckdb` passes the wrong keyword argument
-[`vtasks/jobs/local/maintain.py:27`](vtasks/jobs/local/maintain.py:27)
-
-```python
-duck.sync_duckdb(src=src, dest=dest, schema_prefix=schema_prefixes, mode=mode)
-```
-
-`duck.sync_duckdb` expects `schema_prefixes`, not `schema_prefix`
-([`duck.py:194`](vtasks/common/duck.py:194)). This call raises `TypeError` every time the
-`maintain.sync_duckdb` deployment runs. Fix the keyword name.
-
-### 2. `upload_marts_to_md` references a non-existent constant
-[`vtasks/jobs/local/maintain.py:39`](vtasks/jobs/local/maintain.py:39)
-
-```python
-src=paths.FILE_DUCKDB_DBT,
-```
-
-`paths.py` only defines `FILE_DUCKDB` ([`paths.py:17`](vtasks/common/paths.py:17)); there
-is no `FILE_DUCKDB_DBT`. This raises `AttributeError`. Either add the constant or use the
-correct path. This flow is in `prefect.yaml`, so it is a live deployment.
-
-### 3. `write_df` `mode` type hint omits `"merge"`
-[`vtasks/common/duck.py:137`](vtasks/common/duck.py:137)
-
-The signature is typed `Literal["append", "overwrite"]` but the body handles a third
-`"merge"` mode ([`duck.py:181`](vtasks/common/duck.py:181)) and the merge path is the only
-one that uses the `pk` argument. Add `"merge"` to the `Literal` so the type matches reality
-and callers/linters know it's valid.
-
-### 4. `run_query` ignores `merge` and `sync_duckdb` type vs. default mismatch
-- `duck.sync_duckdb`'s `schema_prefixes` is annotated `str` but defaults to a `list`
-  ([`duck.py:190-195`](vtasks/common/duck.py:190)). Annotate as `list[str]`.
-- `run_flows` in `hourly.py` returns the `states` *module* on success
-  ([`hourly.py:51`](vtasks/schedules/hourly.py:51)) instead of a state/`None`. Harmless
-  today but misleading; return `states.Completed(...)` or nothing.
+> **How to maintain this file.** This is a living checklist of **open** items only. When
+> something here is fixed, **delete its entry in the same change that resolves it** — the
+> rationale and the diff live in git history and the PR that closed it. The list should
+> always reflect what is still pending, never what has already been done. (For example, the
+> correctness/type/security bugs originally listed here were removed when they were fixed in
+> `7.6.2`.)
 
 ## 🧪 Testing
 
@@ -49,7 +16,8 @@ There is **no unit test suite** — the "integration test" in CI just runs the e
 flow against live services ([`CI.yaml:35-64`](.github/workflows/CI.yaml)). This means:
 
 - A PR can't be validated without working production secrets.
-- Pure logic is untested and regressions (like bugs #1–#2) ship silently.
+- Pure logic is untested, so regressions ship silently (several such bugs were only caught
+  by manual review, not CI).
 
 Recommendations:
 - Add `pytest` and unit-test the pure helpers that have no I/O:
@@ -67,7 +35,7 @@ Recommendations:
 - **Undeclared direct dependencies.** `requests` ([`indexa/indexa.py:1`](vtasks/jobs/indexa/indexa.py:1))
   and `loguru` ([`common/logs.py:11`](vtasks/common/logs.py:11)) are imported directly but
   not listed in `pyproject.toml` — they only resolve transitively. A dependency tree change
-  could break imports. Add them explicitly.
+  could break imports. Add them explicitly (and re-run `uv lock`).
 - **Pinned-to-the-patch `prefect==3.2.7`** ([`pyproject.toml:31`](pyproject.toml)). An exact
   pin on the orchestrator blocks security/patch updates. Consider `>=3.2.7,<3.3` unless the
   exact pin is deliberate.
@@ -87,16 +55,15 @@ Recommendations:
   importing the package do real work and raise `RuntimeError` in unrecognized environments,
   which hurts testability. Prefer lazy initialization behind functions.
 - **Global connection cache.** `duck.py` caches `DB_PATH` in a module global
-  ([`duck.py:14-33`](vtasks/common/duck.py)). It caches the *path string*, not a connection,
-  yet the name and `Reusing` log imply connection reuse. Rename for clarity, and note it
-  prevents switching between local/MD within one process.
+  ([`duck.py`](vtasks/common/duck.py)). It caches the *path string*, not a connection, yet
+  the name and `Reusing` log imply connection reuse. Rename for clarity, and note it prevents
+  switching between local/MD within one process.
 
 ## 🔐 Security
 
-- Secrets are encrypted with `vcrypto` (good). Make sure `VTASKS_TOKEN` is never logged —
-  audit the `{var=}` debug logs (e.g. `duck.py` logs the full MotherDuck connection string
-  including the token at [`duck.py:22`](vtasks/common/duck.py:22) via `DB_PATH`). **The
-  token-bearing `DB_PATH` is logged at debug level** — scrub it.
+- Secrets are encrypted with `vcrypto` (good). Keep auditing `{var=}`-style debug logs across
+  the jobs for any secret-bearing values before they reach a sink (the MotherDuck connection
+  string in `duck.py` is already redacted; other call sites should get the same treatment).
 - Account numbers and API endpoints are hard-coded in source
   ([`indexa/indexa.py:9`](vtasks/jobs/indexa/indexa.py:9),
   [`crypto/main.py`](vtasks/jobs/crypto/main.py)). Low risk for a private repo, but consider
@@ -104,13 +71,13 @@ Recommendations:
 
 ## 🧱 Code structure & maintainability
 
-- **Duplicated `sync_duckdb` docstring/signature** between
-  [`maintain.py`](vtasks/jobs/local/maintain.py) and [`duck.py`](vtasks/common/duck.py),
-  already drifted out of sync (the docstring says default `"raw__"` but the code uses
-  `["_marts__", "_core__"]`). Keep one source of truth.
+- **`maintain.sync_duckdb` is a thin wrapper** around `duck.sync_duckdb`
+  ([`maintain.py`](vtasks/jobs/local/maintain.py), [`duck.py`](vtasks/common/duck.py)) with a
+  duplicated signature/docstring that has to be kept in sync by hand. Consider collapsing it
+  so there is one source of truth.
 - **Repetitive phase flows in `hourly.py`.** `maintain`/`updates`/`export`/`post_dbt` are
-  four near-identical wrappers ([`hourly.py:54-75`](vtasks/schedules/hourly.py)). A small
-  factory or a loop over `JOBS` would remove the duplication.
+  four near-identical wrappers ([`hourly.py`](vtasks/schedules/hourly.py)). A small factory or
+  a loop over `JOBS` would remove the duplication.
 - **`paths.get_path` reimplements `os.path.join`/`Path`** with a manual split loop
   ([`paths.py:49-57`](vtasks/common/paths.py)). Use `PATH_ROOT.joinpath(*parts)`.
 - Consider a top-level `CONTRIBUTING`/dev section or `Makefile`/`taskipy` targets so the
@@ -131,14 +98,4 @@ Recommendations:
 - The `pre_commit` job and the local hooks can drift (hook versions are pinned in
   `.pre-commit-config.yaml`). Add a scheduled `prek autoupdate` / Dependabot for actions
   and hooks.
-- CI uses mixed `actions/checkout` versions (`@v4` in one job,
-  [`@v3`](.github/workflows/CI.yaml:38) in another) — standardize on `@v4`.
 - Consider caching `uv` downloads in CI to speed up the integration job.
-
-## 📚 Documentation
-
-- `README.md` example `uv run python -m vtasks.jobs.dropbox.export_tables` points at a
-  module that doesn't exist (the dropbox job is `money_lover.py`). Update the example.
-- Document the environment-detection rules and the `is_pro()` production gate prominently —
-  it's the single most surprising behavior for a new contributor (now captured in
-  `AGENTS.md`).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ uv run python -m vtasks.schedules.hourly
 
 To run a specific job, use **module-based execution**:
 ```bash
-uv run python -m vtasks.jobs.dropbox.export_tables
+uv run python -m vtasks.jobs.dropbox.money_lover
 ```
 This ensures that **relative imports** work correctly.
 

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ definitions:
       name: default-pool
 
   version: &version
-    version: 7.6.1
+    version: 7.6.2
 
   # Define defaults (that can be overwritten)
   defaults: &defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.6.1"
+version = "7.6.2"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.6.1"
+current_version = "7.6.2"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/vtasks/common/duck.py
+++ b/vtasks/common/duck.py
@@ -14,12 +14,19 @@ SECRET_MD = "MOTHERDUCK_TOKEN"
 DB_PATH = None
 
 
+def _redact_token(db_path):
+    """Hide the MotherDuck token before logging a connection string."""
+    if db_path and "motherduck_token=" in db_path:
+        return db_path.split("motherduck_token=")[0] + "motherduck_token=***"
+    return db_path
+
+
 def get_duckdb(use_md=False, filename=None):
     logger = get_logger()
 
     global DB_PATH
     if DB_PATH is not None:
-        logger.debug(f"Reusing {DB_PATH=}")
+        logger.debug(f"Reusing DB_PATH={_redact_token(DB_PATH)}")
         return duckdb.connect(DB_PATH)
 
     if (is_pro := paths.is_pro()) or use_md:
@@ -134,7 +141,7 @@ def write_df(
     df_input,
     schema,
     table,
-    mode: Literal["append", "overwrite"] = "overwrite",
+    mode: Literal["append", "overwrite", "merge"] = "overwrite",
     pk=None,
     as_str=False,
     use_md=False,
@@ -190,7 +197,7 @@ def write_df(
 def sync_duckdb(
     src: str = "dbt",
     dest: str = "motherduck",
-    schema_prefixes: str = ["_marts__", "_core__"],
+    schema_prefixes: list[str] = ["_marts__", "_core__"],
     mode: Literal["append", "overwrite"] = "overwrite",
 ):
     """

--- a/vtasks/jobs/local/maintain.py
+++ b/vtasks/jobs/local/maintain.py
@@ -11,7 +11,7 @@ from vtasks.common.logs import get_logger
 def sync_duckdb(
     src: str = "dbt",
     dest: str = "motherduck",
-    schema_prefixes: str = ["_marts__", "_core__"],
+    schema_prefixes: list[str] = ["_marts__", "_core__"],
     mode: Literal["append", "overwrite"] = "overwrite",
 ):
     """
@@ -20,11 +20,11 @@ def sync_duckdb(
     Args:
         src (str): Source database. Either "motherduck" or a DuckDB file path.
         dest (str): Destination database. Either "motherduck" or a DuckDB file path.
-        schema_prefix (str): Only copy schemas that start with this prefix (default: "raw__").
+        schema_prefixes (list[str]): Only copy schemas that start with any of these prefixes.
         mode (str): Sync mode, either "append" or "overwrite" (default: "overwrite").
     """
 
-    duck.sync_duckdb(src=src, dest=dest, schema_prefix=schema_prefixes, mode=mode)
+    duck.sync_duckdb(src=src, dest=dest, schema_prefixes=schema_prefixes, mode=mode)
 
 
 @flow(name="maintain.upload_marts_to_md")
@@ -36,7 +36,7 @@ def upload_marts_to_md():
         return False
 
     duck.sync_duckdb(
-        src=paths.FILE_DUCKDB_DBT,
+        src=paths.FILE_DUCKDB,
         dest="motherduck",
         schema_prefixes=["_marts__", "_core__"],
         mode="overwrite",

--- a/vtasks/schedules/hourly.py
+++ b/vtasks/schedules/hourly.py
@@ -48,7 +48,7 @@ def run_flows(flows, flow_name):
         return states.Failed(message=msg)
 
     logger.info(f"{flow_name} completed successfully!")
-    return states
+    return states.Completed(message=f"{flow_name} completed successfully!")
 
 
 @flow(name=f"{FLOW_NAME}.maintain")

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -1,5 +1,5 @@
 name: vdbt
-version: '7.6.1'
+version: '7.6.2'
 
 profile: vdbt
 


### PR DESCRIPTION
## Summary
Fixes the correctness/type/security issues catalogued in `IMPROVEMENTS.md`, bumps the version to **7.6.2**, and prunes the now-resolved items from `IMPROVEMENTS.md` (keeping it a list of *open* work only).

## Code fixes
- **`maintain.sync_duckdb`**: pass `schema_prefixes=` (was `schema_prefix=` → `TypeError` on every run of the deployment).
- **`upload_marts_to_md`**: use `paths.FILE_DUCKDB` (the referenced `paths.FILE_DUCKDB_DBT` did not exist → `AttributeError`). dbt's local target writes to the same `villoro.duckdb` file, so this is the intended source.
- **`duck.write_df`**: add `"merge"` to the `mode` `Literal` (the branch already exists and is the only one using `pk`).
- **`duck.sync_duckdb` / `maintain.sync_duckdb`**: type `schema_prefixes` as `list[str]` (was `str` with a list default).
- **`duck.get_duckdb`**: redact the MotherDuck token before logging the connection string (`_redact_token`) — it was previously logged in full at debug level.
- **`hourly.run_flows`**: return `states.Completed(...)` on success (was returning the `states` *module*).

## Docs / CI
- `README`: fix stale run example (`vtasks.jobs.dropbox.money_lover`).
- `CI`: bump `integration_tests` checkout to `actions/checkout@v4`.
- `IMPROVEMENTS.md`: remove every item resolved by this branch and document the convention that resolved entries are deleted in the same change that fixes them.
- `AGENTS.md`: drop the now-stale "maintain.py has known bugs" gotcha.

## Version
Patch bump `7.6.1 → 7.6.2` across `pyproject.toml`, `prefect.yaml`, `dbt_project.yml` (satisfies the `check_version` CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)