### PR TITLE
Protect main from direct pushes in no-commit-to-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
       - id: no-commit-to-branch
+        args: ['--branch', 'main']
       - id: pretty-format-json
 
   # Force good order on imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.6.5"
+version = "7.6.6"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.6.5"
+current_version = "7.6.6"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "vtasks"
-version = "7.6.5"
+version = "7.6.6"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
The `no-commit-to-branch` hook had no args, so it only protected `master` by default, not this repo's `main`. Also migrated branch protection to a Ruleset that blocks direct pushes to `main`, with a scoped admin bypass for merging via PR.