### PR TITLE
Feat/exclude home

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ definitions:
       name: default-pool
 
   version: &version
-    version: 7.7.0
+    version: 7.7.1
 
   # Define defaults (that can be overwritten)
   defaults: &defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.7.0"
+version = "7.7.1"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.7.0"
+current_version = "7.7.1"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "vtasks"
-version = "7.7.0"
+version = "7.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -1,5 +1,5 @@
 name: vdbt
-version: '7.7.0'
+version: '7.7.1'
 
 profile: vdbt
 

--- a/vtasks/vdbt/macros/smoothing.sql
+++ b/vtasks/vdbt/macros/smoothing.sql
@@ -6,7 +6,7 @@
 
     WITH _source AS (
         SELECT
-            date_trunc('month', {{ date_column }}) AS month,
+            date_trunc('month', {{ date_column }}) AS month_date,
             {% for dim in dims -%}
                 {{ dim }},
             {% endfor -%}
@@ -17,10 +17,10 @@
 
     _months AS (
         SELECT unnest(range(
-            min(month),
-            max(month) + INTERVAL 1 MONTH,
+            min(month_date),
+            max(month_date) + INTERVAL 1 MONTH,
             INTERVAL 1 MONTH
-        )) :: date AS month
+        )) :: date AS month_date
         FROM _source
     ),
 
@@ -40,14 +40,14 @@
 
     _joined AS (
         SELECT
-            _grid.month,
+            _grid.month_date,
             {% for dim in dims -%}
                 _grid.{{ dim }},
             {% endfor -%}
             _source.{{ measure }} AS _raw_value
         FROM _grid
         LEFT JOIN _source
-            ON _grid.month = _source.month
+            ON _grid.month_date = _source.month_date
             {% for dim in dims -%}
                 AND _grid.{{ dim }} IS NOT DISTINCT FROM _source.{{ dim }}
             {% endfor %}
@@ -55,7 +55,7 @@
 
     _filled AS (
         SELECT
-            month,
+            month_date,
             {% for dim in dims -%}
                 {{ dim }},
             {% endfor -%}
@@ -66,7 +66,7 @@
                     _raw_value,
                     last_value(_raw_value IGNORE NULLS) OVER (
                         {% if dims %}PARTITION BY {{ dims | join(', ') }}{% endif %}
-                        ORDER BY month
+                        ORDER BY month_date
                         ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                     ),
                     0
@@ -98,7 +98,7 @@
     WITH _indexed AS (
         SELECT
             *,
-            date_diff('month', DATE '1970-01-01', month) AS _m
+            date_diff('month', DATE '1970-01-01', month_date) AS _m
         FROM {{ relation }}
     ),
 
@@ -123,7 +123,7 @@
 
     _filtered AS (
         SELECT
-            base.month,
+            base.month_date,
             {% for dim in dims -%}
                 base.{{ dim }},
             {% endfor -%}
@@ -146,14 +146,14 @@
 
     _smoothed AS (
         SELECT
-            month,
+            month_date,
             {% for dim in dims -%}
                 {{ dim }},
             {% endfor -%}
             {% if post_window > 1 -%}
             avg(_savgol) OVER (
                 {% if dims %}PARTITION BY {{ dims | join(', ') }}{% endif %}
-                ORDER BY month
+                ORDER BY month_date
                 ROWS BETWEEN {{ post_half }} PRECEDING AND {{ post_half }} FOLLOWING
             ) AS {{ out_column }}
             {%- else -%}
@@ -167,7 +167,7 @@
         round(_smoothed.{{ out_column }}, 2) AS {{ out_column }}
     FROM {{ relation }} AS source
     INNER JOIN _smoothed
-        ON source.month = _smoothed.month
+        ON source.month_date = _smoothed.month_date
         {% for dim in dims -%}
             AND source.{{ dim }} IS NOT DISTINCT FROM _smoothed.{{ dim }}
         {% endfor %}

--- a/vtasks/vdbt/macros/smoothing.yml
+++ b/vtasks/vdbt/macros/smoothing.yml
@@ -63,7 +63,7 @@ macros:
 
 
       `relation` must already be a complete monthly grid produced by `monthly_grid`, and it
-      must expose a `month` column, which is what the filter indexes on. The macro expands
+      must expose a `month_date` column, which is what the filter indexes on. The macro expands
       to a full `WITH ... SELECT` query, so the call must be wrapped in its own CTE.
     arguments:
       - name: relation

--- a/vtasks/vdbt/models/core/expensor/core_expensor__monthly.sql
+++ b/vtasks/vdbt/models/core/expensor/core_expensor__monthly.sql
@@ -1,10 +1,11 @@
 WITH transactions AS (
     SELECT * FROM {{ ref('marts_expensor__transactions') }}
+    WHERE NOT is_excluded
 ),
 
 by_type AS (
     SELECT
-        date_trunc('month', transaction_date) AS month,
+        date_trunc('month', transaction_date) AS month_date,
         transaction_type AS category,
         sum(personal_amount) AS value_eur
     FROM transactions
@@ -16,7 +17,7 @@ by_type AS (
 -- so it can safely be built here as just another category.
 result AS (
     SELECT
-        month,
+        month_date,
         'result' AS category,
         sum(CASE WHEN category = 'incomes' THEN value_eur ELSE -value_eur END) AS value_eur
     FROM by_type
@@ -33,7 +34,7 @@ combined AS (
 grid AS (
     {{ monthly_grid(
         relation='combined',
-        date_column='month',
+        date_column='month_date',
         measure='value_eur',
         dims=['category'],
         fill='zero'
@@ -43,7 +44,7 @@ grid AS (
 final AS (
     SELECT
         -------- dims
-        month,
+        month_date,
         category,
 
         -------- measures
@@ -52,7 +53,7 @@ final AS (
         -------- metadata
         is_filled
     FROM grid
-    WHERE month <= date_trunc('month', CURRENT_DATE)
+    WHERE month_date <= date_trunc('month', CURRENT_DATE)
     ORDER BY ALL
 )
 

--- a/vtasks/vdbt/models/core/expensor/core_expensor__monthly.yml
+++ b/vtasks/vdbt/models/core/expensor/core_expensor__monthly.yml
@@ -6,16 +6,17 @@ models:
       Monthly incomes, expenses and result, on a complete month grid.
       Months with no transaction for a category are present with a value of 0,
       which is what makes the smoothing in `marts_expensor__monthly_trends` correct.
+      Excludes the transactions flagged `is_excluded`.
 
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - month
+            - month_date
             - category
 
     columns:
       # -------- pks
-      - name: month
+      - name: month_date
         description: First day of the month
         tests: [not_null]
       - name: category

--- a/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_trends.sql
+++ b/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_trends.sql
@@ -21,7 +21,7 @@ WITH smoothed AS (
 final AS (
     SELECT
         -------- dims
-        month,
+        month_date,
         category,
 
         -------- measures
@@ -35,7 +35,7 @@ final AS (
         -- the series, not to today: if the pipeline lags, the provisional region
         -- has to move with the data. Flagged rather than dropped so the dashboard
         -- keeps the choice.
-        month > (SELECT max(month) FROM smoothed) - INTERVAL {{ window_size // 2 }} MONTH
+        month_date > (SELECT max(month_date) FROM smoothed) - INTERVAL {{ window_size // 2 }} MONTH
             AS is_provisional_trend
     FROM smoothed
     ORDER BY ALL

--- a/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_trends.yml
+++ b/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_trends.yml
@@ -11,12 +11,12 @@ models:
     tests:
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
-            - month
+            - month_date
             - category
 
     columns:
       # -------- pks
-      - name: month
+      - name: month_date
         description: First day of the month
         tests: [not_null]
       - name: category

--- a/vtasks/vdbt/models/marts/expensor/marts_expensor__totals.sql
+++ b/vtasks/vdbt/models/marts/expensor/marts_expensor__totals.sql
@@ -4,6 +4,7 @@ WITH account_values AS (
 
 transactions AS (
     SELECT * FROM {{ ref('marts_expensor__transactions') }}
+    WHERE NOT is_excluded
 ),
 
 invested AS (


### PR DESCRIPTION
Follow-up to #386.

## Exclude `is_excluded` transactions

`core_expensor__monthly` was aggregating every transaction, including the ones flagged `is_excluded`. Those are now filtered out, so the monthly figures and the trend built on them only cover transactions that count.

`marts_expensor__totals` gets the same filter, so the two stay consistent. Verified they reconcile exactly: cumulative expenses in `totals` equals the sum of monthly expenses, to 0.

## Rename `month` to `month_date`

Matches the convention of the other date columns in the project (`change_date`, `transaction_date`, `read_date`). It's the grid column the smoothing macros index on, so it touches both macros and both models.

**Breaking for anything already built on `month`** — worth a look if any Metabase question references it.

## Validation

`dbt build`: 20 PASS, 0 ERROR.

Tested against a fixture where excluded rows were 9 000 EUR/month — expenses average 1 976 EUR rather than ~11 000 EUR, confirming the filter applies. The grid still reconstructs months with no income at all.

Note: the numeric check from #386 (0.00 deviation against the pre-2023 report trend) could **not** be repeated — the `2025_02.html` reference file is no longer available. The macro logic is untouched, but excluding these transactions legitimately changes the values, so there is no reference to compare against now.

Still not run against real MotherDuck data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)