### PR TITLE
Feat/books smoothing

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ definitions:
       name: default-pool
 
   version: &version
-    version: 7.7.1
+    version: 7.7.2
 
   # Define defaults (that can be overwritten)
   defaults: &defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.7.1"
+version = "7.7.2"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.7.1"
+current_version = "7.7.2"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "vtasks"
-version = "7.7.1"
+version = "7.7.2"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -83,6 +83,10 @@ models:
       +tags: core
       +materialized: table
 
+      books:
+        +tags: books
+        +schema: core__books
+
       expensor:
         +tags: expensor
         +schema: core__expensor

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -1,5 +1,5 @@
 name: vdbt
-version: '7.7.1'
+version: '7.7.2'
 
 profile: vdbt
 

--- a/vtasks/vdbt/macros/smoothing.sql
+++ b/vtasks/vdbt/macros/smoothing.sql
@@ -172,3 +172,52 @@
             AND source.{{ dim }} IS NOT DISTINCT FROM _smoothed.{{ dim }}
         {% endfor %}
 {% endmacro %}
+
+
+{% macro gaussian_smooth(
+    relation,
+    measure,
+    dims=[],
+    sigma=3,
+    truncate=3,
+    out_column='trend'
+) %}
+
+    {%- set half = (sigma * truncate) | round(0, 'ceil') | int -%}
+
+    WITH _indexed AS (
+        SELECT
+            *,
+            date_diff('month', DATE '1970-01-01', month_date) AS _m
+        FROM {{ relation }}
+    ),
+
+    _smoothed AS (
+        SELECT
+            base.month_date,
+            {% for dim in dims -%}
+                base.{{ dim }},
+            {% endfor -%}
+            -- Dividing by the sum of the weights renormalises the kernel where it is
+            -- truncated, so the edges of the series need no special casing
+            sum(exp(-0.5 * pow((neighbour._m - base._m) / {{ sigma }}.0, 2)) * neighbour.{{ measure }})
+                / sum(exp(-0.5 * pow((neighbour._m - base._m) / {{ sigma }}.0, 2))) AS {{ out_column }}
+        FROM _indexed AS base
+        INNER JOIN _indexed AS neighbour
+            ON abs(neighbour._m - base._m) <= {{ half }}
+            {% for dim in dims -%}
+                AND neighbour.{{ dim }} IS NOT DISTINCT FROM base.{{ dim }}
+            {% endfor %}
+        GROUP BY ALL
+    )
+
+    SELECT
+        source.*,
+        round(_smoothed.{{ out_column }}, 2) AS {{ out_column }}
+    FROM {{ relation }} AS source
+    INNER JOIN _smoothed
+        ON source.month_date = _smoothed.month_date
+        {% for dim in dims -%}
+            AND source.{{ dim }} IS NOT DISTINCT FROM _smoothed.{{ dim }}
+        {% endfor %}
+{% endmacro %}

--- a/vtasks/vdbt/macros/smoothing.yml
+++ b/vtasks/vdbt/macros/smoothing.yml
@@ -40,6 +40,11 @@ macros:
 
   - name: savgol_smooth
     description: >
+      Use this for dense aggregate series, the monthly totals: incomes, expenses, result.
+      For sparse detail series, such as a breakdown by category, use `gaussian_smooth`
+      instead.
+
+
       Adds a smoothed column to a monthly series using a Savitzky-Golay filter, optionally
       followed by a short centred moving average.
 
@@ -87,5 +92,57 @@ macros:
         description: >
           Size of the centred moving average applied after the filter. Must be odd. Use 1 to
           disable it. Defaults to 3.
+      - name: out_column
+        description: Name of the smoothed column that is added. Defaults to `trend`.
+
+  - name: gaussian_smooth
+    description: >
+      Use this for sparse detail series, such as a breakdown by category, where months
+      with no data are common. For dense aggregate series, the monthly totals, use
+      `savgol_smooth` instead: it tracks turning points faster.
+
+
+      Adds a smoothed column to a monthly series using a Gaussian kernel, that is a
+      weighted moving average where the weight of a neighbour falls off with the square of
+      its distance in months.
+
+
+      Unlike `savgol_smooth` the weights are all positive, so the result of smoothing
+      non-negative values can never go negative. That makes this the right choice for
+      sparse or spiky series such as counts per category, where the negative lobes of a
+      Savitzky-Golay filter would ring below zero around an isolated spike. The trade-off
+      is that it lags at turning points, since a weighted mean cannot bend to a peak the
+      way a fitted polynomial can.
+
+
+      The weights are computed inline rather than read from the `smoothing_weights` seed,
+      so any `sigma` works without generating anything first.
+
+
+      The filter is centred, so it uses future months as well as past ones and the most
+      recent months keep moving as data arrives. Where the kernel is truncated, at the
+      edges of the series, dividing by the sum of the weights renormalises it.
+
+
+      `relation` must already be a complete monthly grid produced by `monthly_grid`, and it
+      must expose a `month_date` column. The macro expands to a full `WITH ... SELECT`
+      query, so the call must be wrapped in its own CTE.
+    arguments:
+      - name: relation
+        description: Relation holding the complete monthly grid, either a `ref()` or the name of an earlier CTE.
+      - name: measure
+        description: Numeric column to smooth.
+      - name: dims
+        description: >
+          List of dimension columns that identify each series. Each combination is smoothed
+          independently. Defaults to an empty list, which smooths a single series.
+      - name: sigma
+        description: >
+          Width of the kernel in months. Larger values give a smoother, flatter curve.
+          Defaults to 3.
+      - name: truncate
+        description: >
+          How many sigmas out the kernel is cut off, which bounds the join. Defaults to 3,
+          where the neglected weight is under 1% and the cost stays O(n * sigma).
       - name: out_column
         description: Name of the smoothed column that is added. Defaults to `trend`.

--- a/vtasks/vdbt/models/core/books/core_books__monthly.sql
+++ b/vtasks/vdbt/models/core/books/core_books__monthly.sql
@@ -1,0 +1,54 @@
+WITH books AS (
+    SELECT * FROM {{ ref('marts_books__read') }}
+    WHERE read_date IS NOT NULL
+),
+
+by_month AS (
+    SELECT
+        date_trunc('month', read_date) AS month_date,
+        count(*) AS books,
+        sum(num_pages) AS pages,
+        -- `total_hours` comes from a left join against the calendar, so it is
+        -- null for books with no reading events logged.
+        sum(coalesce(total_hours, 0)) AS hours
+    FROM books
+    GROUP BY ALL
+),
+
+-- Long format, one row per metric, so a single grid and a single smoothing
+-- pass cover all three.
+long AS (
+    UNPIVOT by_month
+    ON books, pages, hours
+    INTO NAME metric VALUE value
+),
+
+-- Fills the months with no book finished at all, which are common and would
+-- otherwise make the months either side of the gap behave as consecutive.
+grid AS (
+    {{ monthly_grid(
+        relation='long',
+        date_column='month_date',
+        measure='value',
+        dims=['metric'],
+        fill='zero'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        metric,
+
+        -------- measures
+        round(value, 2) AS value,
+
+        -------- metadata
+        is_filled
+    FROM grid
+    WHERE month_date <= date_trunc('month', CURRENT_DATE)
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/core/books/core_books__monthly.yml
+++ b/vtasks/vdbt/models/core/books/core_books__monthly.yml
@@ -1,0 +1,37 @@
+version: 2
+
+models:
+  - name: core_books__monthly
+    description: >
+      Books finished, pages read and hours spent reading per month, in long format,
+      on a complete month grid.
+      Months with no book finished are present with a value of 0, which is what makes
+      the smoothing in `marts_books__monthly_trends` correct.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - metric
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: metric
+        description: Which measure the row holds
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['books', 'pages', 'hours']
+
+      # -------- measures
+      - name: value
+        description: Value of the metric for the month
+        tests: [not_null]
+
+      # -------- metadata
+      - name: is_filled
+        description: True when no book was finished that month and the value was filled with 0
+        tests: [not_null]

--- a/vtasks/vdbt/models/marts/books/marts_books__monthly_trends.sql
+++ b/vtasks/vdbt/models/marts/books/marts_books__monthly_trends.sql
@@ -1,0 +1,42 @@
+{#
+    Gaussian rather than Savitzky-Golay: books finished per month is a sparse,
+    spiky, non-negative series, and the negative lobes of a savgol filter would
+    ring below zero around an isolated month with several books.
+#}
+{% set sigma = 3 %}
+{% set truncate = 3 %}
+
+WITH smoothed AS (
+    {{ gaussian_smooth(
+        relation=ref('core_books__monthly'),
+        measure='value',
+        dims=['metric'],
+        sigma=sigma,
+        truncate=truncate,
+        out_column='trend'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        metric,
+
+        -------- measures
+        value,
+        trend,
+
+        -------- metadata
+        is_filled,
+        -- The kernel is centred, so the newest months only see half of it and
+        -- their trend keeps moving as data arrives. Relative to the end of the
+        -- series rather than to today, so it follows the data if reading is
+        -- logged late.
+        month_date > (SELECT max(month_date) FROM smoothed) - INTERVAL {{ sigma * truncate }} MONTH
+            AS is_provisional_trend
+    FROM smoothed
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/marts/books/marts_books__monthly_trends.yml
+++ b/vtasks/vdbt/models/marts/books/marts_books__monthly_trends.yml
@@ -1,0 +1,49 @@
+version: 2
+
+models:
+  - name: marts_books__monthly_trends
+    description: >
+      `core_books__monthly` with a smoothed trend column.
+      The smoother is a Gaussian kernel with sigma of 3 months, chosen over the
+      Savitzky-Golay filter used for the expensor series because books per month is
+      sparse and non-negative, and Gaussian weights cannot produce a negative trend.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - metric
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: metric
+        description: Which measure the row holds
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['books', 'pages', 'hours']
+
+      # -------- measures
+      - name: value
+        description: Value of the metric for the month
+        tests: [not_null]
+      - name: trend
+        description: Smoothed value of the metric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      # -------- metadata
+      - name: is_filled
+        description: True when no book was finished that month and the value was filled with 0
+        tests: [not_null]
+      - name: is_provisional_trend
+        description: >
+          True for the last sigma * truncate months, where the centred kernel only sees
+          part of its width and the trend will still move as new months arrive.
+        tests: [not_null]


### PR DESCRIPTION
Smoothed monthly trends for reading, next to the real monthly totals.

**`gaussian_smooth`** — second kernel, weights all positive so the trend can't go negative. Computed inline with `exp()`, no seed needed. Macro docs now say which to use: `savgol_smooth` for dense totals, `gaussian_smooth` for sparse detail.

**Models** — `core_books__monthly` (month x `books`/`pages`/`hours`, zero-filled grid) and `marts_books__monthly_trends` (adds `trend`).

`dbt build`: 17 PASS, 0 ERROR. Not run against MotherDuck.

Two things to check:
- Included 3 metrics, not just book counts. Easy to trim.
- `sigma = 3` is a guess — never tuned against the real series.