### PR TITLE
Feat/smoothing by category

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ definitions:
       name: default-pool
 
   version: &version
-    version: 7.7.2
+    version: 7.8.0
 
   # Define defaults (that can be overwritten)
   defaults: &defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.7.2"
+version = "7.8.0"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.7.2"
+current_version = "7.8.0"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "vtasks"
-version = "7.7.2"
+version = "7.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -1,5 +1,5 @@
 name: vdbt
-version: '7.7.2'
+version: '7.8.0'
 
 profile: vdbt
 

--- a/vtasks/vdbt/models/core/books/core_books__monthly_by_language.sql
+++ b/vtasks/vdbt/models/core/books/core_books__monthly_by_language.sql
@@ -1,0 +1,54 @@
+WITH books AS (
+    SELECT * FROM {{ ref('marts_books__read') }}
+    WHERE read_date IS NOT NULL
+),
+
+by_month AS (
+    SELECT
+        date_trunc('month', read_date) AS month_date,
+        language,
+        count(*) AS books,
+        sum(num_pages) AS pages,
+        -- `total_hours` comes from a left join against the calendar, so it is
+        -- null for books with no reading events logged.
+        sum(coalesce(total_hours, 0)) AS hours
+    FROM books
+    GROUP BY ALL
+),
+
+long AS (
+    UNPIVOT by_month
+    ON books, pages, hours
+    INTO NAME metric VALUE value
+),
+
+-- Most language-months have no book finished at all, so the grid does more
+-- work here than in any other series.
+grid AS (
+    {{ monthly_grid(
+        relation='long',
+        date_column='month_date',
+        measure='value',
+        dims=['language', 'metric'],
+        fill='zero'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        language,
+        metric,
+
+        -------- measures
+        round(value, 2) AS value,
+
+        -------- metadata
+        is_filled
+    FROM grid
+    WHERE month_date <= date_trunc('month', CURRENT_DATE)
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/core/books/core_books__monthly_by_language.yml
+++ b/vtasks/vdbt/models/core/books/core_books__monthly_by_language.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: core_books__monthly_by_language
+    description: >
+      Books finished, pages read and hours spent reading per month and language, in long
+      format, on a complete month grid.
+      Language-months with no book finished are present with a value of 0, which is what
+      makes the smoothing in `marts_books__monthly_by_language_trends` correct.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - language
+            - metric
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: language
+        description: Language the book is written in
+        tests: [not_null]
+      - name: metric
+        description: Which measure the row holds
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['books', 'pages', 'hours']
+
+      # -------- measures
+      - name: value
+        description: Value of the metric for the language and month
+        tests: [not_null]
+
+      # -------- metadata
+      - name: is_filled
+        description: True when no book was finished in that language that month and the value was filled with 0
+        tests: [not_null]

--- a/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.sql
+++ b/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.sql
@@ -1,0 +1,47 @@
+WITH transactions AS (
+    SELECT * FROM {{ ref('marts_expensor__transactions') }}
+    WHERE NOT is_excluded
+),
+
+by_category AS (
+    SELECT
+        date_trunc('month', transaction_date) AS month_date,
+        transaction_type,
+        category,
+        sum(personal_amount) AS value_eur
+    FROM transactions
+    GROUP BY ALL
+),
+
+-- The grid expands over the (transaction_type, category) pairs that actually
+-- exist, not their cross product, so income categories never appear under
+-- expenses. Holes are the norm here: most categories have months with no
+-- transaction at all.
+grid AS (
+    {{ monthly_grid(
+        relation='by_category',
+        date_column='month_date',
+        measure='value_eur',
+        dims=['transaction_type', 'category'],
+        fill='zero'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        transaction_type,
+        category,
+
+        -------- measures
+        round(value_eur, 2) AS value_eur,
+
+        -------- metadata
+        is_filled
+    FROM grid
+    WHERE month_date <= date_trunc('month', CURRENT_DATE)
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.yml
+++ b/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.yml
@@ -1,0 +1,41 @@
+version: 2
+
+models:
+  - name: core_expensor__monthly_by_category
+    description: >
+      Monthly totals per transaction category, on a complete month grid.
+      Category-months with no transaction are present with a value of 0, which is what
+      makes the smoothing in `marts_expensor__monthly_by_category_trends` correct.
+      Excludes the transactions flagged `is_excluded`.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - transaction_type
+            - category
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: transaction_type
+        description: Whether the category is an income or an expense one
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['incomes', 'expenses']
+      - name: category
+        description: Name of the transaction category
+        tests: [not_null]
+
+      # -------- measures
+      - name: value_eur
+        description: Total personal amount for the category and month in euros
+        tests: [not_null]
+
+      # -------- metadata
+      - name: is_filled
+        description: True when the category had no transaction that month and the value was filled with 0
+        tests: [not_null]

--- a/vtasks/vdbt/models/marts/books/marts_books__monthly_by_language_trends.sql
+++ b/vtasks/vdbt/models/marts/books/marts_books__monthly_by_language_trends.sql
@@ -1,0 +1,39 @@
+{#
+    Sparser than the overall books series, since each language only gets a
+    share of the months, so the kernel is a bit wider than the sigma of 3 used
+    in `marts_books__monthly_trends`.
+#}
+{% set sigma = 4 %}
+{% set truncate = 3 %}
+
+WITH smoothed AS (
+    {{ gaussian_smooth(
+        relation=ref('core_books__monthly_by_language'),
+        measure='value',
+        dims=['language', 'metric'],
+        sigma=sigma,
+        truncate=truncate,
+        out_column='trend'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        language,
+        metric,
+
+        -------- measures
+        value,
+        trend,
+
+        -------- metadata
+        is_filled,
+        month_date > (SELECT max(month_date) FROM smoothed) - INTERVAL {{ sigma * truncate }} MONTH
+            AS is_provisional_trend
+    FROM smoothed
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/marts/books/marts_books__monthly_by_language_trends.yml
+++ b/vtasks/vdbt/models/marts/books/marts_books__monthly_by_language_trends.yml
@@ -1,0 +1,53 @@
+version: 2
+
+models:
+  - name: marts_books__monthly_by_language_trends
+    description: >
+      `core_books__monthly_by_language` with a smoothed trend column.
+      Long format, so a chart can filter on `metric` and break the series out by
+      `language` to plot every language at once.
+      Smoothed with a Gaussian kernel, whose weights cannot produce a negative trend.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - language
+            - metric
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: language
+        description: Language the book is written in
+        tests: [not_null]
+      - name: metric
+        description: Which measure the row holds
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['books', 'pages', 'hours']
+
+      # -------- measures
+      - name: value
+        description: Value of the metric for the language and month
+        tests: [not_null]
+      - name: trend
+        description: Smoothed value of the metric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      # -------- metadata
+      - name: is_filled
+        description: True when no book was finished in that language that month and the value was filled with 0
+        tests: [not_null]
+      - name: is_provisional_trend
+        description: >
+          True for the last sigma * truncate months, where the centred kernel only sees
+          part of its width and the trend will still move as new months arrive.
+        tests: [not_null]

--- a/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_by_category_trends.sql
+++ b/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_by_category_trends.sql
@@ -1,0 +1,39 @@
+{#
+    Gaussian rather than Savitzky-Golay: per category the series is sparse and
+    spiky, and savgol's negative lobes ring below zero around an isolated large
+    transaction. Amounts are always positive here, so the trend must be too.
+#}
+{% set sigma = 3 %}
+{% set truncate = 3 %}
+
+WITH smoothed AS (
+    {{ gaussian_smooth(
+        relation=ref('core_expensor__monthly_by_category'),
+        measure='value_eur',
+        dims=['transaction_type', 'category'],
+        sigma=sigma,
+        truncate=truncate,
+        out_column='trend_eur'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        transaction_type,
+        category,
+
+        -------- measures
+        value_eur,
+        trend_eur,
+
+        -------- metadata
+        is_filled,
+        month_date > (SELECT max(month_date) FROM smoothed) - INTERVAL {{ sigma * truncate }} MONTH
+            AS is_provisional_trend
+    FROM smoothed
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_by_category_trends.yml
+++ b/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_by_category_trends.yml
@@ -1,0 +1,55 @@
+version: 2
+
+models:
+  - name: marts_expensor__monthly_by_category_trends
+    description: >
+      `core_expensor__monthly_by_category` with a smoothed trend column.
+      Long format, so a chart can filter on `transaction_type` and break the series out
+      by `category` to plot every expense or income category at once.
+      Smoothed with a Gaussian kernel rather than the Savitzky-Golay filter used for the
+      monthly totals, because per category the series is sparse and Gaussian weights
+      cannot produce a negative trend.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - transaction_type
+            - category
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: transaction_type
+        description: Whether the category is an income or an expense one
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['incomes', 'expenses']
+      - name: category
+        description: Name of the transaction category
+        tests: [not_null]
+
+      # -------- measures
+      - name: value_eur
+        description: Total personal amount for the category and month in euros
+        tests: [not_null]
+      - name: trend_eur
+        description: Smoothed value in euros
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      # -------- metadata
+      - name: is_filled
+        description: True when the category had no transaction that month and the value was filled with 0
+        tests: [not_null]
+      - name: is_provisional_trend
+        description: >
+          True for the last sigma * truncate months, where the centred kernel only sees
+          part of its width and the trend will still move as new months arrive.
+        tests: [not_null]


### PR DESCRIPTION
Per-category and per-language smoothed trends, in long format so Metabase can plot all series at once (filter `transaction_type` / `metric`, break out by `category` / `language`).

New models, no macro changes — `gaussian_smooth` already took multiple dims:

| | |
|---|---|
| `core_expensor__monthly_by_category` + `marts_expensor__monthly_by_category_trends` | month x type x category |
| `core_books__monthly_by_language` + `marts_books__monthly_by_language_trends` | month x language x metric |

The grid expands over `(transaction_type, category)` pairs that exist, not their cross product, so income categories don't appear under expenses.

This is the case that justified the second kernel: on a category with 1 non-zero month out of 158, savgol rings down to **-9.38** while Gaussian stays at 0. Both models assert the trend is never negative.

`dbt build`: 19 PASS each, 0 ERROR. Not run against MotherDuck.

`sigma` is 3 for categories and 4 for languages — both guesses, never tuned against real data.