### PR TITLE
Feat/gcal smoothing

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ definitions:
       name: default-pool
 
   version: &version
-    version: 7.9.0
+    version: 7.10.0
 
   # Define defaults (that can be overwritten)
   defaults: &defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.9.0"
+version = "7.10.0"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.9.0"
+current_version = "7.10.0"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "vtasks"
-version = "7.9.0"
+version = "7.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -1,5 +1,5 @@
 name: vdbt
-version: '7.9.0'
+version: '7.10.0'
 
 profile: vdbt
 

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -87,6 +87,10 @@ models:
         +tags: books
         +schema: core__books
 
+      gcal:
+        +tags: gcal
+        +schema: core__gcal
+
       expensor:
         +tags: expensor
         +schema: core__expensor

--- a/vtasks/vdbt/models/core/gcal/core_gcal__monthly.sql
+++ b/vtasks/vdbt/models/core/gcal/core_gcal__monthly.sql
@@ -1,0 +1,42 @@
+WITH daily_stats AS (
+    SELECT * FROM {{ ref('marts_gcal__daily_stats') }}
+    WHERE is_personal
+),
+
+by_calendar AS (
+    SELECT
+        date_trunc('month', start_day) AS month_date,
+        calendar_name,
+        sum(duration_hours) AS duration_hours
+    FROM daily_stats
+    GROUP BY ALL
+),
+
+-- Calendars come and go, so most of them have months with no event at all.
+grid AS (
+    {{ monthly_grid(
+        relation='by_calendar',
+        date_column='month_date',
+        measure='duration_hours',
+        dims=['calendar_name'],
+        fill='zero'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        calendar_name,
+
+        -------- measures
+        round(duration_hours, 2) AS duration_hours,
+
+        -------- metadata
+        is_filled
+    FROM grid
+    WHERE month_date <= date_trunc('month', CURRENT_DATE)
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/core/gcal/core_gcal__monthly.yml
+++ b/vtasks/vdbt/models/core/gcal/core_gcal__monthly.yml
@@ -1,0 +1,34 @@
+version: 2
+
+models:
+  - name: core_gcal__monthly
+    description: >
+      Hours logged per month and personal calendar, on a complete month grid.
+      Non-personal calendars, the work ones, are excluded.
+      Calendar-months with no event are present with a value of 0, which is what makes
+      the smoothing in `marts_gcal__monthly_trends` correct.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - calendar_name
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: calendar_name
+        description: Name of the calendar
+        tests: [not_null]
+
+      # -------- measures
+      - name: duration_hours
+        description: Hours logged for the calendar and month
+        tests: [not_null]
+
+      # -------- metadata
+      - name: is_filled
+        description: True when the calendar had no event that month and the value was filled with 0
+        tests: [not_null]

--- a/vtasks/vdbt/models/marts/gcal/marts_gcal__monthly_trends.sql
+++ b/vtasks/vdbt/models/marts/gcal/marts_gcal__monthly_trends.sql
@@ -1,0 +1,38 @@
+{#
+    Gaussian rather than Savitzky-Golay: hours per calendar is sparse, calendars
+    start and stop being used, and hours are always positive so the trend must
+    be too.
+#}
+{% set sigma = 3 %}
+{% set truncate = 3 %}
+
+WITH smoothed AS (
+    {{ gaussian_smooth(
+        relation=ref('core_gcal__monthly'),
+        measure='duration_hours',
+        dims=['calendar_name'],
+        sigma=sigma,
+        truncate=truncate,
+        out_column='trend_hours'
+    ) }}
+),
+
+final AS (
+    SELECT
+        -------- dims
+        month_date,
+        calendar_name,
+
+        -------- measures
+        duration_hours,
+        trend_hours,
+
+        -------- metadata
+        is_filled,
+        month_date > (SELECT max(month_date) FROM smoothed) - INTERVAL {{ sigma * truncate }} MONTH
+            AS is_provisional_trend
+    FROM smoothed
+    ORDER BY ALL
+)
+
+SELECT * FROM final

--- a/vtasks/vdbt/models/marts/gcal/marts_gcal__monthly_trends.yml
+++ b/vtasks/vdbt/models/marts/gcal/marts_gcal__monthly_trends.yml
@@ -1,0 +1,46 @@
+version: 2
+
+models:
+  - name: marts_gcal__monthly_trends
+    description: >
+      `core_gcal__monthly` with a smoothed trend column.
+      Long format, so a chart can break the series out by `calendar_name` to plot every
+      calendar at once.
+      Smoothed with a Gaussian kernel, whose weights cannot produce a negative trend.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - month_date
+            - calendar_name
+
+    columns:
+      # -------- pks
+      - name: month_date
+        description: First day of the month
+        tests: [not_null]
+      - name: calendar_name
+        description: Name of the calendar
+        tests: [not_null]
+
+      # -------- measures
+      - name: duration_hours
+        description: Hours logged for the calendar and month
+        tests: [not_null]
+      - name: trend_hours
+        description: Smoothed hours
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      # -------- metadata
+      - name: is_filled
+        description: True when the calendar had no event that month and the value was filled with 0
+        tests: [not_null]
+      - name: is_provisional_trend
+        description: >
+          True for the last sigma * truncate months, where the centred kernel only sees
+          part of its width and the trend will still move as new months arrive.
+        tests: [not_null]


### PR DESCRIPTION
Smoothed monthly trends per calendar.

`core_gcal__monthly` rolls `marts_gcal__daily_stats` up from daily to monthly hours per calendar on a complete grid; `marts_gcal__monthly_trends` adds `trend_hours`.

Only personal calendars — work ones filtered out. No totals here, unlike the books and expensor models.

Plot: x `month_date`, y `trend_hours`, series `calendar_name`.

The grid matters here because calendars come and go: one that stopped being used keeps producing zero-filled months, so its trend decays to zero instead of ending abruptly.

Gaussian rather than savgol, since hours per calendar is sparse and always positive. `sigma = 3`, untuned.

`dbt build`: 15 PASS, 0 ERROR. Not run against MotherDuck.