### PR TITLE
Feat/total capitalized

### DIFF
--- a/prefect.yaml
+++ b/prefect.yaml
@@ -18,7 +18,7 @@ definitions:
       name: default-pool
 
   version: &version
-    version: 7.10.0
+    version: 7.10.1
 
   # Define defaults (that can be overwritten)
   defaults: &defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vtasks"
-version = "7.10.0"
+version = "7.10.1"
 description = "Personal tasks scheduled with Prefect"
 authors = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
 maintainers = [{ name = "Arnau Villoro", email = "arnau@villoro.com" }]
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [tool.bumpversion]
-current_version = "7.10.0"
+current_version = "7.10.1"
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -3449,7 +3449,7 @@ wheels = [
 
 [[package]]
 name = "vtasks"
-version = "7.10.0"
+version = "7.10.1"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },

--- a/vtasks/vdbt/dbt_project.yml
+++ b/vtasks/vdbt/dbt_project.yml
@@ -1,5 +1,5 @@
 name: vdbt
-version: '7.10.0'
+version: '7.10.1'
 
 profile: vdbt
 

--- a/vtasks/vdbt/models/core/books/core_books__monthly_by_language.sql
+++ b/vtasks/vdbt/models/core/books/core_books__monthly_by_language.sql
@@ -22,7 +22,7 @@ by_language AS (
 totals AS (
     SELECT
         date_trunc('month', read_date) AS month_date,
-        'total' AS language,
+        'Total' AS language,
         count(*) AS books,
         sum(num_pages) AS pages,
         sum(coalesce(total_hours, 0)) AS hours
@@ -64,7 +64,7 @@ final AS (
         round(value, 2) AS value,
 
         -------- metadata
-        language = 'total' AS is_total,
+        language = 'Total' AS is_total,
         is_filled
     FROM grid
     WHERE month_date <= date_trunc('month', CURRENT_DATE)

--- a/vtasks/vdbt/models/core/books/core_books__monthly_by_language.yml
+++ b/vtasks/vdbt/models/core/books/core_books__monthly_by_language.yml
@@ -7,7 +7,7 @@ models:
       format, on a complete month grid.
       Language-months with no book finished are present with a value of 0, which is what
       makes the smoothing in `marts_books__monthly_by_language_trends` correct.
-      Carries an extra `total` language holding the sum across languages, so a chart gets
+      Carries an extra `Total` language holding the sum across languages, so a chart gets
       one trace per language plus the total from a single breakout. Anything aggregating
       across languages must filter it out with `is_total`, or it double counts.
 
@@ -24,7 +24,7 @@ models:
         description: First day of the month
         tests: [not_null]
       - name: language
-        description: Language the book is written in, or `total` for the sum across all of them
+        description: Language the book is written in, or `Total` for the sum across all of them
         tests: [not_null]
       - name: metric
         description: Which measure the row holds
@@ -40,7 +40,7 @@ models:
 
       # -------- metadata
       - name: is_total
-        description: True for the `total` rows, which must be excluded when summing across languages
+        description: True for the `Total` rows, which must be excluded when summing across languages
         tests: [not_null]
       - name: is_filled
         description: True when no book was finished in that language that month and the value was filled with 0

--- a/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.sql
+++ b/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.sql
@@ -23,7 +23,7 @@ totals AS (
     SELECT
         date_trunc('month', transaction_date) AS month_date,
         transaction_type,
-        'total' AS category,
+        'Total' AS category,
         sum(personal_amount) AS value_eur
     FROM transactions
     GROUP BY ALL
@@ -59,7 +59,7 @@ final AS (
         round(value_eur, 2) AS value_eur,
 
         -------- metadata
-        category = 'total' AS is_total,
+        category = 'Total' AS is_total,
         is_filled
     FROM grid
     WHERE month_date <= date_trunc('month', CURRENT_DATE)

--- a/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.yml
+++ b/vtasks/vdbt/models/core/expensor/core_expensor__monthly_by_category.yml
@@ -7,7 +7,7 @@ models:
       Category-months with no transaction are present with a value of 0, which is what
       makes the smoothing in `marts_expensor__monthly_by_category_trends` correct.
       Excludes the transactions flagged `is_excluded`.
-      Carries an extra `total` category per transaction_type, so a chart gets one trace
+      Carries an extra `Total` category per transaction_type, so a chart gets one trace
       per category plus the total from a single breakout. Anything aggregating across
       categories must filter it out with `is_total`, or it double counts.
 
@@ -30,7 +30,7 @@ models:
           - accepted_values:
               values: ['incomes', 'expenses']
       - name: category
-        description: Name of the transaction category, or `total` for the sum across all of them
+        description: Name of the transaction category, or `Total` for the sum across all of them
         tests: [not_null]
 
       # -------- measures
@@ -40,7 +40,7 @@ models:
 
       # -------- metadata
       - name: is_total
-        description: True for the `total` rows, which must be excluded when summing across categories
+        description: True for the `Total` rows, which must be excluded when summing across categories
         tests: [not_null]
       - name: is_filled
         description: True when the category had no transaction that month and the value was filled with 0

--- a/vtasks/vdbt/models/marts/books/marts_books__monthly_by_language_trends.yml
+++ b/vtasks/vdbt/models/marts/books/marts_books__monthly_by_language_trends.yml
@@ -6,7 +6,7 @@ models:
       `core_books__monthly_by_language` with a smoothed trend column.
       Long format, so a chart can filter on `metric` and break the series out by
       `language` to plot every language plus the total at once.
-      Anything aggregating across languages must exclude the `total` rows with `is_total`,
+      Anything aggregating across languages must exclude the `Total` rows with `is_total`,
       or it double counts.
       Smoothed with a Gaussian kernel, whose weights cannot produce a negative trend.
 
@@ -23,7 +23,7 @@ models:
         description: First day of the month
         tests: [not_null]
       - name: language
-        description: Language the book is written in, or `total` for the sum across all of them
+        description: Language the book is written in, or `Total` for the sum across all of them
         tests: [not_null]
       - name: metric
         description: Which measure the row holds
@@ -46,7 +46,7 @@ models:
 
       # -------- metadata
       - name: is_total
-        description: True for the `total` rows, which must be excluded when summing across languages
+        description: True for the `Total` rows, which must be excluded when summing across languages
         tests: [not_null]
       - name: is_filled
         description: True when no book was finished in that language that month and the value was filled with 0

--- a/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_by_category_trends.yml
+++ b/vtasks/vdbt/models/marts/expensor/marts_expensor__monthly_by_category_trends.yml
@@ -6,7 +6,7 @@ models:
       `core_expensor__monthly_by_category` with a smoothed trend column.
       Long format, so a chart can filter on `transaction_type` and break the series out
       by `category` to plot every expense or income category plus the total at once.
-      Anything aggregating across categories must exclude the `total` rows with
+      Anything aggregating across categories must exclude the `Total` rows with
       `is_total`, or it double counts.
       Note the total here is Gaussian smoothed; `marts_expensor__monthly_trends` keeps the
       Savitzky-Golay one, which tracks turning points faster.
@@ -33,7 +33,7 @@ models:
           - accepted_values:
               values: ['incomes', 'expenses']
       - name: category
-        description: Name of the transaction category, or `total` for the sum across all of them
+        description: Name of the transaction category, or `Total` for the sum across all of them
         tests: [not_null]
 
       # -------- measures
@@ -50,7 +50,7 @@ models:
 
       # -------- metadata
       - name: is_total
-        description: True for the `total` rows, which must be excluded when summing across categories
+        description: True for the `Total` rows, which must be excluded when summing across categories
         tests: [not_null]
       - name: is_filled
         description: True when the category had no transaction that month and the value was filled with 0


### PR DESCRIPTION
Renames the aggregate row from `total` to `Total`, so it reads as a proper label next to the real names in a chart legend.

- `core_books__monthly_by_language` — language is now `english / spanish / catalan / Total`
- `core_expensor__monthly_by_category` — category is now `Rent / Payroll / … / Total`

gcal has no aggregate row, so it is untouched.

**Breaking** for any Metabase question filtering on the literal `'total'`.

`dbt build`: 44 PASS, 0 ERROR. Not run against MotherDuck.